### PR TITLE
Add smaller cube clone

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -23,6 +23,10 @@ fn main() {
         cgmath::Vector3::new(-0.5, -0.5, -0.5),
         cgmath::Vector3::new(0.5, 0.5, 0.5),
     );
+    let small_cube_collider = Aabb::new(
+        cgmath::Vector3::new(-1.25, -0.25, -0.25),
+        cgmath::Vector3::new(-0.75, 0.25, 0.25),
+    );
 
     let mut input_state = InputState::default();
     let mut last_frame = std::time::Instant::now();
@@ -97,7 +101,7 @@ fn main() {
                 let dt = now.duration_since(last_frame).as_secs_f32();
                 last_frame = now;
 
-                let colliders = [cube_collider];
+                let colliders = [cube_collider, small_cube_collider];
                 if input_state.forward { camera.process_keyboard_collision(CameraMovement::Forward, dt, &colliders); }
                 if input_state.backward { camera.process_keyboard_collision(CameraMovement::Backward, dt, &colliders); }
                 if input_state.left { camera.process_keyboard_collision(CameraMovement::Left, dt, &colliders); }

--- a/src/vulkan_app/app.rs
+++ b/src/vulkan_app/app.rs
@@ -79,7 +79,14 @@ impl VulkanApp {
             &queue_family_indices,
             &VERTICES,
         );
-        let wire_vertices = generate_wireframe_vertices(24);
+        let mut wire_vertices = generate_wireframe_vertices(24);
+        let mut small_wire = generate_wireframe_vertices(24);
+        for v in &mut small_wire {
+            v.pos[0] = v.pos[0] * 0.5 - 1.0;
+            v.pos[1] *= 0.5;
+            v.pos[2] *= 0.5;
+        }
+        wire_vertices.extend_from_slice(&small_wire);
         let wireframe_vertex_count = wire_vertices.len() as u32;
         let (wireframe_vertex_buffer, wireframe_vertex_buffer_memory) =
             buffers::create_vertex_buffer(

--- a/src/vulkan_app/vertex.rs
+++ b/src/vulkan_app/vertex.rs
@@ -35,48 +35,43 @@ impl Vertex {
     }
 }
 
-pub const VERTICES: [Vertex; 8] = [
-    Vertex {
-        pos: [-0.5, -0.5, 0.5],
-        color: [0.298, 0.686, 0.314],
-    },
-    Vertex {
-        pos: [0.5, -0.5, 0.5],
-        color: [0.298, 0.686, 0.314],
-    },
-    Vertex {
-        pos: [0.5, 0.5, 0.5],
-        color: [0.298, 0.686, 0.314],
-    },
-    Vertex {
-        pos: [-0.5, 0.5, 0.5],
-        color: [0.298, 0.686, 0.314],
-    },
-    Vertex {
-        pos: [-0.5, -0.5, -0.5],
-        color: [0.298, 0.686, 0.314],
-    },
-    Vertex {
-        pos: [0.5, -0.5, -0.5],
-        color: [0.298, 0.686, 0.314],
-    },
-    Vertex {
-        pos: [0.5, 0.5, -0.5],
-        color: [0.298, 0.686, 0.314],
-    },
-    Vertex {
-        pos: [-0.5, 0.5, -0.5],
-        color: [0.298, 0.686, 0.314],
-    },
+pub const VERTICES: [Vertex; 16] = [
+    // Big cube
+    Vertex { pos: [-0.5, -0.5, 0.5],  color: [0.298, 0.686, 0.314] },
+    Vertex { pos: [0.5, -0.5, 0.5],   color: [0.298, 0.686, 0.314] },
+    Vertex { pos: [0.5, 0.5, 0.5],    color: [0.298, 0.686, 0.314] },
+    Vertex { pos: [-0.5, 0.5, 0.5],   color: [0.298, 0.686, 0.314] },
+    Vertex { pos: [-0.5, -0.5, -0.5], color: [0.298, 0.686, 0.314] },
+    Vertex { pos: [0.5, -0.5, -0.5],  color: [0.298, 0.686, 0.314] },
+    Vertex { pos: [0.5, 0.5, -0.5],   color: [0.298, 0.686, 0.314] },
+    Vertex { pos: [-0.5, 0.5, -0.5],  color: [0.298, 0.686, 0.314] },
+
+    // Smaller cube translated to the left
+    Vertex { pos: [-1.25, -0.25, 0.25],  color: [0.298, 0.686, 0.314] },
+    Vertex { pos: [-0.75, -0.25, 0.25],  color: [0.298, 0.686, 0.314] },
+    Vertex { pos: [-0.75, 0.25, 0.25],   color: [0.298, 0.686, 0.314] },
+    Vertex { pos: [-1.25, 0.25, 0.25],   color: [0.298, 0.686, 0.314] },
+    Vertex { pos: [-1.25, -0.25, -0.25], color: [0.298, 0.686, 0.314] },
+    Vertex { pos: [-0.75, -0.25, -0.25], color: [0.298, 0.686, 0.314] },
+    Vertex { pos: [-0.75, 0.25, -0.25],  color: [0.298, 0.686, 0.314] },
+    Vertex { pos: [-1.25, 0.25, -0.25],  color: [0.298, 0.686, 0.314] },
 ];
 
-pub const INDICES: [u16; 36] = [
+pub const INDICES: [u16; 72] = [
     0, 1, 2, 2, 3, 0, // front
     4, 6, 5, 4, 7, 6, // back
     0, 7, 4, 0, 3, 7, // left
     1, 5, 6, 6, 2, 1, // right
     3, 2, 6, 6, 7, 3, // top
     0, 5, 1, 5, 0, 4, // bottom
+
+    // Small cube (offset 8)
+    8, 9, 10, 10, 11, 8, // front
+    12, 14, 13, 12, 15, 14, // back
+    8, 15, 12, 8, 11, 15, // left
+    9, 13, 14, 14, 10, 9, // right
+    11, 10, 14, 14, 15, 11, // top
+    8, 13, 9, 13, 8, 12, // bottom
 ];
 
 pub fn generate_wireframe_vertices(divisions: u32) -> Vec<Vertex> {


### PR DESCRIPTION
## Summary
- duplicate cube geometry at half scale and translated left
- extend indices for second cube
- duplicate wireframe vertex generation with transform
- add collider for smaller cube

## Testing
- `cargo check` *(fails: build was interrupted due to slow dependency downloads)*

------
https://chatgpt.com/codex/tasks/task_e_6886a46bd64083228c137017f605b125