### PR TITLE
Add third cube

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -27,6 +27,10 @@ fn main() {
         cgmath::Vector3::new(-1.25, -0.25, -0.25),
         cgmath::Vector3::new(-0.75, 0.25, 0.25),
     );
+    let tiny_cube_collider = Aabb::new(
+        cgmath::Vector3::new(-1.7, -0.1, -0.1),
+        cgmath::Vector3::new(-1.5, 0.1, 0.1),
+    );
 
     let mut input_state = InputState::default();
     let mut last_frame = std::time::Instant::now();
@@ -101,7 +105,7 @@ fn main() {
                 let dt = now.duration_since(last_frame).as_secs_f32();
                 last_frame = now;
 
-                let colliders = [cube_collider, small_cube_collider];
+                let colliders = [cube_collider, small_cube_collider, tiny_cube_collider];
                 if input_state.forward { camera.process_keyboard_collision(CameraMovement::Forward, dt, &colliders); }
                 if input_state.backward { camera.process_keyboard_collision(CameraMovement::Backward, dt, &colliders); }
                 if input_state.left { camera.process_keyboard_collision(CameraMovement::Left, dt, &colliders); }

--- a/src/vulkan_app/app.rs
+++ b/src/vulkan_app/app.rs
@@ -87,6 +87,13 @@ impl VulkanApp {
             v.pos[2] *= 0.5;
         }
         wire_vertices.extend_from_slice(&small_wire);
+        let mut tiny_wire = generate_wireframe_vertices(24);
+        for v in &mut tiny_wire {
+            v.pos[0] = v.pos[0] * 0.2 - 1.6;
+            v.pos[1] *= 0.2;
+            v.pos[2] *= 0.2;
+        }
+        wire_vertices.extend_from_slice(&tiny_wire);
         let wireframe_vertex_count = wire_vertices.len() as u32;
         let (wireframe_vertex_buffer, wireframe_vertex_buffer_memory) =
             buffers::create_vertex_buffer(

--- a/src/vulkan_app/vertex.rs
+++ b/src/vulkan_app/vertex.rs
@@ -35,7 +35,7 @@ impl Vertex {
     }
 }
 
-pub const VERTICES: [Vertex; 16] = [
+pub const VERTICES: [Vertex; 24] = [
     // Big cube
     Vertex { pos: [-0.5, -0.5, 0.5],  color: [0.298, 0.686, 0.314] },
     Vertex { pos: [0.5, -0.5, 0.5],   color: [0.298, 0.686, 0.314] },
@@ -55,9 +55,19 @@ pub const VERTICES: [Vertex; 16] = [
     Vertex { pos: [-0.75, -0.25, -0.25], color: [0.298, 0.686, 0.314] },
     Vertex { pos: [-0.75, 0.25, -0.25],  color: [0.298, 0.686, 0.314] },
     Vertex { pos: [-1.25, 0.25, -0.25],  color: [0.298, 0.686, 0.314] },
+
+    // Tiny cube translated further to the left
+    Vertex { pos: [-1.7, -0.1, 0.1],  color: [0.298, 0.686, 0.314] },
+    Vertex { pos: [-1.5, -0.1, 0.1],  color: [0.298, 0.686, 0.314] },
+    Vertex { pos: [-1.5, 0.1, 0.1],   color: [0.298, 0.686, 0.314] },
+    Vertex { pos: [-1.7, 0.1, 0.1],   color: [0.298, 0.686, 0.314] },
+    Vertex { pos: [-1.7, -0.1, -0.1], color: [0.298, 0.686, 0.314] },
+    Vertex { pos: [-1.5, -0.1, -0.1], color: [0.298, 0.686, 0.314] },
+    Vertex { pos: [-1.5, 0.1, -0.1],  color: [0.298, 0.686, 0.314] },
+    Vertex { pos: [-1.7, 0.1, -0.1],  color: [0.298, 0.686, 0.314] },
 ];
 
-pub const INDICES: [u16; 72] = [
+pub const INDICES: [u16; 108] = [
     0, 1, 2, 2, 3, 0, // front
     4, 6, 5, 4, 7, 6, // back
     0, 7, 4, 0, 3, 7, // left
@@ -72,6 +82,14 @@ pub const INDICES: [u16; 72] = [
     9, 13, 14, 14, 10, 9, // right
     11, 10, 14, 14, 15, 11, // top
     8, 13, 9, 13, 8, 12, // bottom
+
+    // Tiny cube (offset 16)
+    16, 17, 18, 18, 19, 16, // front
+    20, 22, 21, 20, 23, 22, // back
+    16, 23, 20, 16, 19, 23, // left
+    17, 21, 22, 22, 18, 17, // right
+    19, 18, 22, 22, 23, 19, // top
+    16, 21, 17, 21, 16, 20, // bottom
 ];
 
 pub fn generate_wireframe_vertices(divisions: u32) -> Vec<Vertex> {


### PR DESCRIPTION
## Summary
- add vertices and indices for a tiny cube to the left
- generate wireframe data for the new cube
- include collider for tiny cube in main

## Testing
- `cargo build --quiet`

------
https://chatgpt.com/codex/tasks/task_e_6886b08c6a188322b65bc94d7ef80702